### PR TITLE
Simplify this tool into thin wrapper around protoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# This Dockerfile produces an image that runs the protocol compiler
+# to generate Go declarations for messages and Twirp RPC interfaces.
+#
+# For build reproducibility, it is explicit about the versions of its
+# dependencies, which include:
+# - the golang base docker image (linux, go, git),
+# - protoc,
+# - Go packages (protoc-gen-go and protoc-gen-twirp),
+# - apt packages (unzip).
+
+FROM golang:1.16.5
+
+WORKDIR /work
+
+RUN apt-get update && \
+    apt-get install -y unzip=6.0-23+deb10u2 && \
+    curl --location --silent -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip && \
+    unzip protoc.zip -d /usr/local/ && \
+    rm -fr protoc.zip
+
+RUN go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.20.0 \
+           github.com/twitchtv/twirp/protoc-gen-twirp@v5.12.1+incompatible
+
+ENTRYPOINT ["protoc"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # proto-gen-go
 
-This tool makes it easy to reliably generate and update Go definitions
-for messages and services defined in .proto files.
+This tool is a thin wrapper around protoc, the protocol compiler. It
+makes it easy to reliably generate and update Go definitions for
+messages and services defined in .proto files. It uses a docker
+container with explicitly versioned dependencies to ensure maximum
+reproducibility and minimum side effects.
 
 In your Go project's proto directory, add a `gen.go` file with the following contents:
 
 ```go
 package proto
-//go:generate sh -c "cd .. && go run github.com/github/proto-gen-go@latest"
+//go:generate sh -c "go run github.com/github/proto-gen-go@latest [protoc flags] [proto files]"
 ```
 
 Now, when you run `go generate` in your proto directory, the script

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"flag"
 	"fmt"
 	"log"
@@ -50,6 +51,10 @@ import (
 	"os/exec"
 	"strings"
 )
+
+// dockerfile contains the docker specification for our versioned dependencies
+//go:embed Dockerfile
+var dockerfile string
 
 func main() {
 	log.SetPrefix("proto-gen-go: ")
@@ -90,29 +95,3 @@ func main() {
 	}
 	log.Println("done")
 }
-
-// This Dockerfile produces an image that runs the protocol compiler
-// to generate Go declarations for messages and Twirp RPC interfaces.
-//
-// For build reproducibility, it is explicit about the versions of its
-// dependencies, which include:
-// - the golang base docker image (linux, go, git),
-// - protoc,
-// - Go packages (protoc-gen-go and protoc-gen-twirp),
-// - apt packages (unzip).
-const dockerfile = `
-FROM golang:1.16.5
-
-WORKDIR /work
-
-RUN apt-get update && \
-    apt-get install -y unzip=6.0-23+deb10u2 && \
-    curl --location --silent -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip && \
-    unzip protoc.zip -d /usr/local/ && \
-    rm -fr protoc.zip
-
-RUN go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.20.0 \
-           github.com/twitchtv/twirp/protoc-gen-twirp@v5.12.1+incompatible
-
-ENTRYPOINT ["protoc"]
-`


### PR DESCRIPTION
This change causes the proto-gen-go tool to act as nothing more than a trivial wrapper around a single invocation of protoc---in a container, with explicit versions, with the Go and Twirp plugins. Clients need a greater variety of invocations than the simplistic approach used before.

We should rename the repo to protoc-docker once this lands.