### PR TITLE
Update all tools to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,17 @@
 # - Go packages (protoc-gen-go and protoc-gen-twirp),
 # - apt packages (unzip).
 
-FROM golang:1.16.5
+FROM golang:1.17.6
 
 WORKDIR /work
 
 RUN apt-get update && \
-    apt-get install -y unzip=6.0-23+deb10u2 && \
-    curl --location --silent -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip && \
+    apt-get install -y unzip=6.0-26 && \
+    curl --location --silent -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip && \
     unzip protoc.zip -d /usr/local/ && \
     rm -fr protoc.zip
 
-RUN go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.20.0 \
-           github.com/twitchtv/twirp/protoc-gen-twirp@v5.12.1+incompatible
+RUN go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1 \
+           github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.1+incompatible
 
 ENTRYPOINT ["protoc"]


### PR DESCRIPTION
golang (docker) 1.17.6
unzip (apt) 6.0-26
google.golang.org/protobuf (Go) v1.27.1
github.com/twitchtv/twirp/protoc-gen-twirp (Go) v8.1.1+incompatible

I propose to tag this v1.1.0.