### PR TITLE
Use install > get as it will stop building bins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     unzip protoc.zip -d /usr/local/ && \
     rm -fr protoc.zip
 
-RUN go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1 \
-           github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.1+incompatible
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1 && \
+           go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.1+incompatible
 
 ENTRYPOINT ["protoc"]


### PR DESCRIPTION
Though at this point we still use Go 1.17, 1.18 release notes say: 

> go get no longer builds or installs packages in module-aware mode

Ref: https://tip.golang.org/doc/go1.18

Also, I've never done `go install <mod1> <mod2>` but trying it locally, I need to make sure to run both of them separately otherwise Go thinks `<mod2>` must belong to `<mod1>` 


```
$ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest github.com/twitchtv/twirp/protoc-gen-twirp@latest
go: finding module for package github.com/twitchtv/twirp/protoc-gen-twirp
go: finding module for package github.com/pkg/errors
go: found github.com/pkg/errors in github.com/pkg/errors v0.9.1
package github.com/twitchtv/twirp/protoc-gen-twirp provided by module github.com/twitchtv/twirp@v8.1.1+incompatible
	All packages must be provided by the same module (google.golang.org/protobuf@v1.27.1)
```

vs

```
$ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest && go install github.com/twitchtv/twirp/protoc-gen-twirp@latest
go: finding module for package github.com/pkg/errors
go: finding module for package google.golang.org/protobuf/types/pluginpb
go: finding module for package google.golang.org/protobuf/proto
go: finding module for package google.golang.org/protobuf/types/descriptorpb
go: found github.com/pkg/errors in github.com/pkg/errors v0.9.1
go: found google.golang.org/protobuf/proto in google.golang.org/protobuf v1.27.1
go: found google.golang.org/protobuf/types/descriptorpb in google.golang.org/protobuf v1.27.1
go: found google.golang.org/protobuf/types/pluginpb in google.golang.org/protobuf v1.27.1
```