### PR TITLE
use linux/amd64 platform when running on M1 macs

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,6 @@ func main() {
 
 	// Build the protoc container image specified by the Dockerfile.
 	// The docker context is empty.
-	log.Printf("goos=%q goarch=%q", runtime.GOOS, runtime.GOARCH)
 	log.Printf("building protoc container image...")
 	args := []string{"build"}
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 )
 
@@ -73,14 +72,11 @@ func main() {
 	}
 
 	// Build the protoc container image specified by the Dockerfile.
+	// The dockerized program assumes linux/amd64, and the --platform flag enables
+	// dynamic binary translation on M1 hardware.
 	// The docker context is empty.
 	log.Printf("building protoc container image...")
-	args := []string{"build"}
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		args = append(args, "--platform=linux/amd64")
-	}
-	args = append(args, "-q", "-")
-	cmd := exec.Command("docker", args...)
+	cmd := exec.Command("docker", "build", "--platform=linux/amd64", "-q", "-")
 	cmd.Stdin = strings.NewReader(dockerfile)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = new(bytes.Buffer)
@@ -97,12 +93,7 @@ func main() {
 	// Run protoc, in a container.
 	// We assume pwd does not conflict with some critical part
 	// of the docker image, and volume-mount it.
-	args = []string{"run", "-v", pwd + ":" + pwd}
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		args = append(args, "--platform=linux/amd64")
-	}
-	args = append(args, id)
-	cmd = exec.Command("docker", args...)
+	cmd = exec.Command("docker", "run", "-v", pwd+":"+pwd, "--platform=linux/amd64", id)
 	cmd.Args = append(cmd.Args, protocArgs...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stderr


### PR DESCRIPTION
This doesn't work on M1 macs:

```
$ go run github.com/github/proto-gen-go@v1.1.0
proto-gen-go: building protoc container image...
proto-gen-go: protoc
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
proto-gen-go: protoc command failed: exit status 255
exit status 1
```

This PR adds `--platform=linux/amd64` when it detects it's running on an M1.

After:

```
$ go run .
proto-gen-go: building protoc container image...
proto-gen-go: protoc
Usage: /usr/local/bin/protoc [OPTION] PROTO_FILES
[...]
```

An alternative might be trying an arm64-specific base image, but I wasn't able to figure that out.