### PR TITLE
Reference v1.3.0 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your Go project's proto directory, add a `gen.go` file with the following con
 
 ```go
 package proto
-//go:generate sh -c "go run github.com/github/proto-gen-go@v1.2.0 [flags] [--] [protoc flags] [proto files]"
+//go:generate sh -c "go run github.com/github/proto-gen-go@v1.3.0 [flags] [--] [protoc flags] [proto files]"
 ```
 
 (The `go run module@version` command requires Go 1.17 or later.)


### PR DESCRIPTION
`v1.2.0` is broken (see #12), so we should reference the latest version in the README.