### PR TITLE
Add ruby and upgrade modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN apt-get update && \
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
         go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.3+incompatible && \
-        go install github.com/twitchtv/twirp-ruby@v1.9.0
+        go install github.com/twitchtv/twirp-ruby/protoc-gen-twirp_ruby@v1.9.0
 
 ENTRYPOINT ["protoc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && \
     unzip protoc.zip -d /usr/local/ && \
     rm -fr protoc.zip
 
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0 && \
-           go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.2+incompatible
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
+        go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.3+incompatible && \
+        go install github.com/twitchtv/twirp-ruby@v1.9.0
 
 ENTRYPOINT ["protoc"]


### PR DESCRIPTION
This PR adds the ruby-twirp protoc plugin to the dockerfile so it can be run from users who want to generate a ruby twirp file. It also upgrades the patch dependencies of the previous two plugins. 