### PR TITLE
Bump twirp_ruby to version 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN apt-get update && \
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
         go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.3+incompatible && \
-        go install github.com/twitchtv/twirp-ruby/protoc-gen-twirp_ruby@v1.9.0
+        go install github.com/github/twirp-ruby/protoc-gen-twirp_ruby@v1.10.0
 
 ENTRYPOINT ["protoc"]


### PR DESCRIPTION
This PR bumps twirp_ruby to version `1.10.0`. This version includes support for the `optional` keyword.

I changed the path to the generator from `github.com/twitchtv/twirp-ruby/` to `github.com/github/twirp-ruby/` because that is what the original path redirects to.