### PR TITLE
Update go to supported version (1.24)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM golang:1.24
 WORKDIR /work
 
 RUN apt-get update && \
-    apt-get install -y unzip=6.0-28 && \
+    apt-get install -y unzip=6.0-29 && \
     curl --location --silent -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-linux-x86_64.zip && \
     unzip protoc.zip -d /usr/local/ && \
     rm -fr protoc.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # - Go packages (protoc-gen-go and protoc-gen-twirp),
 # - apt packages (unzip).
 
-FROM golang:1.23
+FROM golang:1.24
 
 WORKDIR /work
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/github/proto-gen-go
 
-go 1.23
+go 1.24


### PR DESCRIPTION
1.23 is no longer supported, 1.24 is the minimally supported version (https://endoflife.date/go)

cc https://github.com/github/feature-management/issues/7399